### PR TITLE
chore: add project quality and release infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev, main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test, lint, and package (macOS)
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Run automated test suite
+        run: make test
+
+      - name: Run lint (bash -n + osacompile)
+        run: make lint
+
+      - name: Build a synthetic-version release package
+        run: make dist VERSION=0.0.0-ci
+
+      - name: Verify release package checksums
+        run: |
+          cd dist
+          shasum -a 256 -c iphone-cam-lite-0.0.0-ci-SHA256SUMS.txt
+
+      - name: Clean up local release artifacts
+        if: always()
+        run: make clean-dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Build and publish release artifacts
+    runs-on: macos-14
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Derive version from tag
+        id: version
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          version="${tag#v}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build release artifacts
+        run: make dist VERSION="${{ steps.version.outputs.version }}"
+
+      - name: Verify release package checksums
+        run: |
+          cd dist
+          shasum -a 256 -c "iphone-cam-lite-${{ steps.version.outputs.version }}-SHA256SUMS.txt"
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            "dist/iphone-cam-lite-${{ steps.version.outputs.version }}.tar.gz" \
+            "dist/iphone-cam-lite-${{ steps.version.outputs.version }}.zip" \
+            "dist/iphone-cam-lite-${{ steps.version.outputs.version }}-SHA256SUMS.txt" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --notes "See CHANGELOG.md for details." \
+            --repo "${{ github.repository }}"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 *.log
 .env
+dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- An automated Bash test suite (`tests/run.sh` plus `scripts/test_*.sh`) covering the Makefile, prerequisite checks, the Zoom/Teams launchers, camera/microphone selection, post-selection verification, and safe restart of camera services.
+- A `scripts/build_release.sh` packaging script that produces reproducible `tar.gz` and `zip` release archives plus a `SHA256SUMS.txt` checksum file, along with a matching regression test (`scripts/test_build_release.sh`).
+- `make test`, `make lint`, `make dist`, and `make clean-dist` targets.
+- GitHub Actions workflows for continuous integration (`.github/workflows/ci.yml`) and tag-triggered release packaging (`.github/workflows/release.yml`).
+- `CONTRIBUTING.md` describing how to set up, test, and submit changes.
+- `SECURITY.md` describing how to report a vulnerability.
+
+### Fixed
+
+- Hardened the Zoom and Teams device-selection automation against several real-world failure modes: it now verifies the camera/microphone selection actually took effect instead of assuming a click succeeded, reports AppleScript automation failures instead of failing silently, and works correctly with localized (non-English) menu UIs.
+- Made the camera and microphone device names configurable instead of hardcoded.
+- Fixed the launcher scripts to resolve bundled resources (AppleScript files) relative to the script's own location rather than the caller's current directory, and to match the launched application's process exactly instead of matching on a loose name pattern.
+- Fixed application-launch handling to report a timeout instead of hanging indefinitely.
+- Fixed prerequisite checks to detect the active Wi-Fi interface correctly, avoid a false positive from an obsolete `airport` check, and avoid a false positive from Bluetooth detection.
+- Fixed the Makefile so it parses cleanly (removed stray Markdown code-fence characters) and so the scripts it invokes keep their executable permissions under version control.
+
+## [0.1.2] - 2025-09-17
+
+### Added
+
+- Zoom camera selection support (`scripts/select_zoom_camera.scpt`), so `make zoom` can automatically select the configured camera in Zoom's video settings.
+
+## [0.1.1] - 2025-09-17
+
+### Added
+
+- `scripts/keepawake.sh` and a `make keepawake` target to prevent macOS from sleeping during long calls.
+
+## [0.1.0] - 2025-09-17
+
+### Added
+
+- Initial usable version of the project, including `scripts/reset_camera_services.sh` and a `make reset-camera` target to restart the camera/media agents when a camera stops responding.
+
+[Unreleased]: https://github.com/bubnicbf/iphone-cam-lite/compare/v0.1.2...dev
+[0.1.2]: https://github.com/bubnicbf/iphone-cam-lite/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/bubnicbf/iphone-cam-lite/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/bubnicbf/iphone-cam-lite/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing to iphone-cam-lite
+
+Thanks for considering a contribution. This project is a small collection
+of macOS shell scripts and AppleScript files, so the workflow is
+intentionally lightweight.
+
+## Prerequisites
+
+- macOS (the launchers, AppleScript automation, and `osacompile`/`osascript`
+  syntax checks are all macOS-only).
+- Bash (the scripts target the `bash` that ships with macOS; avoid
+  bash-4+-only features such as associative arrays or `mapfile`).
+- Xcode Command Line Tools, for `osacompile`/`osascript` (`xcode-select --install`).
+
+## Getting set up
+
+```sh
+git clone git@github.com:bubnicbf/iphone-cam-lite.git
+cd iphone-cam-lite
+git checkout dev
+make setup
+```
+
+`make setup` makes the scripts executable and runs `scripts/check_prereqs.sh`
+to confirm your Mac has what it needs.
+
+## Branching
+
+Base new work on `dev`, not `main` -- `dev` is the active integration
+branch. Name branches by the kind of change they make:
+
+- `bug/<short-description>` for bug fixes
+- `feature/<short-description>` for new functionality
+- `chore/<short-description>` for tooling, docs, tests, and other
+  non-user-facing maintenance
+
+Open pull requests against `dev`.
+
+## Running the tests
+
+```sh
+make test
+```
+
+This runs every `scripts/test_*.sh` file via `tests/run.sh`. The test suite
+is entirely mocked/synthetic: it never launches Zoom or Teams, never
+changes your actual camera/microphone selection, and never restarts real
+system services. Scripts under test are exercised against `PATH`-injected
+mock commands and temporary directories, not your live system.
+
+To run a single test directly:
+
+```sh
+./scripts/test_launcher_failures.sh
+```
+
+Adding a new `scripts/test_*.sh` file is picked up automatically by
+`tests/run.sh` -- there's no separate list to update.
+
+## Linting
+
+```sh
+make lint
+```
+
+This runs `bash -n` over every shell script (syntax-only, no execution) and,
+on macOS with the Command Line Tools installed, compiles each `.scpt` file
+with `osacompile` into a throwaway temporary location to confirm it's
+syntactically valid AppleScript. If `osacompile` isn't available, linting
+reports that AppleScript validation was skipped rather than failing --
+please still validate `.scpt` changes by hand (e.g. by opening them in
+Script Editor) before submitting.
+
+## Style
+
+- Shell scripts start with `set -euo pipefail` and should stay compatible
+  with macOS's built-in `bash`.
+- Use `scripts/test_reset_camera_services.sh` or `scripts/test_launcher_failures.sh`
+  as a model for new tests: mock external commands via a temporary `PATH`
+  entry rather than calling real system commands or launching real apps.
+- Match the existing `.editorconfig` settings (2-space indent, LF line
+  endings, trimmed trailing whitespace) -- except in Makefiles, where recipe
+  lines must keep literal tab indentation.
+- AppleScript changes should keep user-facing failures actionable (a
+  specific, distinct message per failure case) rather than folding
+  different failure modes into one generic error.
+
+## Changelog
+
+If your change is user-facing (a fix, a new feature, a behavior change),
+add an entry under `## [Unreleased]` in `CHANGELOG.md`, following the
+existing [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) style.
+Purely internal changes (refactors, test-only changes) don't need an entry.
+
+## Commits and pull requests
+
+- Keep commits focused; prefer a short, imperative summary line (e.g.
+  `fix: report launch timeouts`).
+- Describe what changed and why in the PR description, and mention how you
+  tested it (`make test`, `make lint`, manual verification on macOS, etc.).
+- Make sure `make test` and `make lint` pass before requesting review.
+
+## Reporting security issues
+
+Please don't file a public issue for a security vulnerability -- see
+[SECURITY.md](SECURITY.md) for how to report one privately.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: setup zoom teams keepawake reset-camera test
+.PHONY: setup zoom teams keepawake reset-camera test lint dist clean-dist
 
 setup:
 	chmod +x scripts/*.sh
@@ -19,9 +19,55 @@ reset-camera:
 	./scripts/reset_camera_services.sh
 
 test:
-	./scripts/test_makefile.sh
-	./scripts/test_check_prereqs.sh
-	./scripts/test_launcher_failures.sh
-	./scripts/test_ui_label_configuration.sh
-	./scripts/test_applescript_error_handling.sh
-	./scripts/test_selection_confirmation.sh
+	./tests/run.sh
+
+lint:
+	@status=0; \
+	echo "Checking shell script syntax (bash -n)..."; \
+	while IFS= read -r -d '' f; do \
+		if ! bash -n "$$f"; then \
+			echo "syntax error in $$f" >&2; \
+			status=1; \
+		fi; \
+	done < <(find . -name '*.sh' -not -path './.git/*' -not -path './dist/*' -print0); \
+	if command -v osacompile >/dev/null 2>&1; then \
+		echo "Validating AppleScript sources (osacompile)..."; \
+		tmp_dir=$$(mktemp -d); \
+		for f in scripts/*.scpt; do \
+			[ -e "$$f" ] || continue; \
+			name=$$(basename "$$f" .scpt); \
+			if ! osacompile -o "$$tmp_dir/$$name.scpt" "$$f" >/dev/null 2>&1; then \
+				echo "AppleScript compile failed for $$f" >&2; \
+				status=1; \
+			fi; \
+		done; \
+		rm -rf "$$tmp_dir"; \
+	else \
+		echo "osacompile not found -- skipping AppleScript validation (requires macOS with Xcode Command Line Tools; run 'make lint' there to validate .scpt changes)"; \
+	fi; \
+	exit $$status
+
+dist:
+	@if [ -z "$(VERSION)" ]; then \
+		echo "usage: make dist VERSION=<x.y.z>" >&2; \
+		exit 1; \
+	fi
+	./scripts/build_release.sh "$(VERSION)"
+
+clean-dist:
+	@repo_root="$(CURDIR)"; \
+	if [ -z "$$repo_root" ] || [ "$$repo_root" = "/" ]; then \
+		echo "refusing to run: repository root is unset or is '/'" >&2; \
+		exit 1; \
+	fi; \
+	target="$$repo_root/dist"; \
+	if [ "$$(basename "$$target")" != "dist" ]; then \
+		echo "refusing to remove unexpected path: $$target" >&2; \
+		exit 1; \
+	fi; \
+	if [ -d "$$target" ]; then \
+		rm -rf -- "$$target"; \
+		echo "removed $$target"; \
+	else \
+		echo "nothing to clean ($$target does not exist)"; \
+	fi

--- a/README.md
+++ b/README.md
@@ -144,3 +144,31 @@ use its Title or Description field as the override value.
 	- The app isn't exposing the accessibility attribute this confirmation relies on (for example a menu item's mark character, or a control's value/title) for that control right now -- this can happen after an app update changes what it exposes, or if the relevant window/menu isn't in the expected state. Re-run after bringing the app's window to the front, and check whether a newer version of this repository has an updated confirmation strategy for the installed app version.
 - If the error mentions a confirmation timeout:
 	- The bounded wait (a few seconds, briefly polling) elapsed before the app's accessibility state confirmed the change -- this is deliberate and never indefinite. A consistently slow app, an unusually large device list, or a partially unresponsive UI can all cause this; re-running after the app has fully finished loading its window usually resolves it.
+
+## Testing
+
+```sh
+make test
+```
+
+Runs the full regression suite (`tests/run.sh`, which discovers and runs every `scripts/test_*.sh` file). The suite is entirely mocked: it never launches Zoom or Teams, never changes your actual camera/microphone selection, and never restarts real system services.
+
+```sh
+make lint
+```
+
+Runs `bash -n` over every shell script, and (on macOS with the Xcode Command Line Tools installed) compiles each `.scpt` file with `osacompile` to confirm it's syntactically valid AppleScript.
+
+## Development
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to set up a development environment, the branching model, and what's expected of a pull request.
+
+## Releases
+
+```sh
+make dist VERSION=1.2.3
+```
+
+Builds a release into `dist/` (git-ignored): `iphone-cam-lite-1.2.3.tar.gz`, `iphone-cam-lite-1.2.3.zip`, and a `iphone-cam-lite-1.2.3-SHA256SUMS.txt` checksum file covering both, each containing a single top-level `iphone-cam-lite-1.2.3/` directory with only the runtime files (no tests, no development tooling). Run `make clean-dist` to remove `dist/`.
+
+See [CHANGELOG.md](CHANGELOG.md) for release history, and [SECURITY.md](SECURITY.md) for how to report a vulnerability.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Supported Versions
+
+iphone-cam-lite is a small personal-use automation toolkit, packaged as a
+handful of shell scripts and AppleScript files rather than a service with a
+long-term support cycle. In practice, security fixes are made against the
+latest released version:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.2   | :white_check_mark: |
+| 0.1.1   | :x:                 |
+| 0.1.0   | :x:                 |
+
+Earlier tagged versions are not maintained. If you're running an older
+version, please upgrade to the latest release (or the `dev` branch) before
+reporting an issue, in case it has already been fixed.
+
+## Reporting a Vulnerability
+
+Please do not open a public GitHub issue for a security vulnerability.
+
+Instead, use GitHub's private vulnerability reporting for this repository:
+open the **Security** tab on the [iphone-cam-lite repository](https://github.com/bubnicbf/iphone-cam-lite),
+then **Report a vulnerability**. This opens a private advisory that only
+you and the maintainer can see, and lets you attach details, logs, or
+proof-of-concept material without exposing them publicly.
+
+When reporting, please include:
+
+- The version or commit you're running (`git rev-parse HEAD`, or the release
+  tag/archive name).
+- The platform and macOS version.
+- Steps to reproduce, and what you expected vs. what happened.
+
+Before attaching logs, screenshots, or AppleScript output, please redact
+anything sensitive that isn't relevant to the report -- for example
+Microsoft/Zoom account details or sign-in state, meeting IDs or links,
+calendar or contact information visible in a screenshot, and personal
+device or computer names.
+
+This project is maintained on a best-effort, volunteer basis. There is no
+guaranteed response time or SLA, but reports are read and taken seriously,
+and a fix or mitigation will be prioritized once a report is confirmed.

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Builds reproducible release artifacts for iphone-cam-lite: a tar.gz
+# archive, a zip archive, and a SHA256SUMS file covering both, each named
+# "<project>-<version>.*". Packaging always happens in a temporary staging
+# directory that is removed afterward -- this script never packages
+# directly from, or overwrites, the working tree.
+#
+# Usage: scripts/build_release.sh <version> [output_dir]
+#
+# See usage() below for the full argument description.
+set -euo pipefail
+
+PROJECT_NAME="iphone-cam-lite"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build_release.sh <version> [output_dir]
+
+  <version>     Required. A semantic version, optionally prefixed with "v"
+                (e.g. "1.2.0" or "v1.2.0"). Rejected if empty, malformed,
+                or unsafe for use in a filesystem path or archive entry
+                name. The leading "v" (if present) is accepted but the
+                archive/directory name is always normalized to the bare
+                version, so "v1.2.0" and "1.2.0" produce identical output.
+
+  [output_dir]  Optional. Where to write the release artifacts. Defaults
+                to "dist/" under the repository root. Can also be set via
+                the RELEASE_OUTPUT_DIR environment variable (useful for
+                tests and CI); an explicit argument takes precedence over
+                the variable.
+
+Builds a tar.gz archive, a zip archive, and a "<project>-<version>-
+SHA256SUMS.txt" checksum file covering both, each containing exactly one
+top-level directory named "<project>-<version>". Packaging happens in a
+temporary staging directory (never directly from the working tree, and
+never overwriting source files); the staging directory is always removed
+afterward, even on failure.
+EOF
+}
+
+fail() {
+  echo "build_release.sh: error: $1" >&2
+  exit 1
+}
+
+if [[ $# -lt 1 || -z "${1:-}" ]]; then
+  usage >&2
+  fail "a version argument is required"
+fi
+
+raw_version="$1"
+output_dir_arg="${2:-}"
+
+# Accept an optional leading "v" (as in a Git tag, e.g. "v1.2.0") but
+# normalize the archive/directory name to the bare version consistently.
+version_no_v="${raw_version#v}"
+
+# Strict, conservative semantic-version validation: MAJOR.MINOR.PATCH with
+# an optional -prerelease and/or +build-metadata suffix, using only
+# characters that are always safe in a single path segment and an archive
+# entry name. Anything else -- empty, whitespace, slashes, "..", shell
+# metacharacters, a non-numeric leading component -- is rejected outright
+# rather than silently coerced into something "close enough".
+semver_pattern='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?(\+[0-9A-Za-z][0-9A-Za-z.-]*)?$'
+if [[ ! "$version_no_v" =~ $semver_pattern ]]; then
+  fail "invalid version \"$raw_version\" -- expected MAJOR.MINOR.PATCH, optionally prefixed with 'v' and/or suffixed with -prerelease/+build metadata, e.g. \"1.2.0\" or \"v1.2.0-rc.1\""
+fi
+
+# Belt-and-suspenders: even though the regex above already excludes them,
+# explicitly refuse path-separator/traversal/whitespace characters so a
+# future pattern change can't silently reopen this.
+case "$version_no_v" in
+  */*|*'..'*|*' '*)
+    fail "invalid version \"$raw_version\" -- must not contain '/', '..', or whitespace"
+    ;;
+esac
+
+version_dir_name="${PROJECT_NAME}-${version_no_v}"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Output directory: explicit argument > RELEASE_OUTPUT_DIR env var >
+# "dist/" under the repo root. Resolved to an absolute path so the
+# tar/zip/shasum invocations below are never sensitive to the caller's
+# current working directory.
+if [[ -n "$output_dir_arg" ]]; then
+  output_dir="$output_dir_arg"
+elif [[ -n "${RELEASE_OUTPUT_DIR:-}" ]]; then
+  output_dir="$RELEASE_OUTPUT_DIR"
+else
+  output_dir="$repo_root/dist"
+fi
+mkdir -p "$output_dir"
+output_dir="$(cd "$output_dir" && pwd)"
+
+for tool in tar zip shasum; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    fail "required tool '$tool' was not found on PATH"
+  fi
+done
+
+staging_root="$(mktemp -d)"
+trap 'rm -rf "$staging_root"' EXIT
+
+package_dir="$staging_root/$version_dir_name"
+mkdir -p "$package_dir"
+
+# Copy only the runtime files users actually need -- never the whole
+# working tree, and never anything development-only (.git, .github,
+# tests/, dist/, scripts/test_*.sh, this script itself, editor/temp/log
+# files, _to_delete/, or machine-specific config). This list is
+# deliberately explicit rather than "everything except an exclude
+# pattern", so a stray new dev-only file added later can never silently
+# end up in a release archive.
+copy_file() {
+  local rel="$1"
+  if [[ -f "$repo_root/$rel" ]]; then
+    mkdir -p "$package_dir/$(dirname "$rel")"
+    cp -p "$repo_root/$rel" "$package_dir/$rel"
+  fi
+}
+
+copy_file "Makefile"
+copy_file "README.md"
+copy_file "CHANGELOG.md"
+copy_file "SECURITY.md"
+copy_file "LICENSE"
+copy_file "scripts/check_prereqs.sh"
+copy_file "scripts/start_zoom.sh"
+copy_file "scripts/start_teams.sh"
+copy_file "scripts/keepawake.sh"
+copy_file "scripts/reset_camera_services.sh"
+copy_file "scripts/select_zoom_camera.scpt"
+copy_file "scripts/select_teams_camera.scpt"
+
+if [[ ! -f "$package_dir/Makefile" || ! -f "$package_dir/README.md" ]]; then
+  fail "required runtime files (Makefile, README.md) were not found in the repository -- refusing to build an incomplete release"
+fi
+
+# cp -p above already preserves each source file's executable bit, but
+# assert it explicitly so a future umask/tooling change can't silently
+# ship a non-executable launcher.
+for runnable in start_zoom.sh start_teams.sh check_prereqs.sh keepawake.sh reset_camera_services.sh; do
+  f="$package_dir/scripts/$runnable"
+  if [[ -f "$f" && ! -x "$f" ]]; then
+    chmod +x "$f"
+  fi
+done
+
+tar_path="$output_dir/${version_dir_name}.tar.gz"
+zip_path="$output_dir/${version_dir_name}.zip"
+sums_path="$output_dir/${version_dir_name}-SHA256SUMS.txt"
+
+rm -f "$tar_path" "$zip_path" "$sums_path"
+
+# Both archives are built from inside the staging root, referencing only
+# the versioned directory name, so the only top-level entry in either
+# archive is that directory -- no absolute paths, no staging-directory
+# name leaking in, no parent-directory traversal entries.
+( cd "$staging_root" && tar -czf "$tar_path" "$version_dir_name" )
+( cd "$staging_root" && zip -rq "$zip_path" "$version_dir_name" )
+
+if [[ ! -s "$tar_path" ]]; then
+  fail "tar.gz archive was not created or is empty: $tar_path"
+fi
+if [[ ! -s "$zip_path" ]]; then
+  fail "zip archive was not created or is empty: $zip_path"
+fi
+
+( cd "$output_dir" && shasum -a 256 "$(basename "$tar_path")" "$(basename "$zip_path")" > "$sums_path" )
+
+if [[ ! -s "$sums_path" ]]; then
+  fail "SHA256SUMS file was not created or is empty: $sums_path"
+fi
+
+echo "Release artifacts for $PROJECT_NAME $version_no_v:"
+echo "  $tar_path"
+echo "  $zip_path"
+echo "  $sums_path"

--- a/scripts/test_build_release.sh
+++ b/scripts/test_build_release.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Regression coverage for scripts/build_release.sh: builds a real (but
+# synthetic-version) release into an isolated temporary directory, then
+# inspects the resulting tar.gz, zip, and SHA256SUMS artifacts. Never
+# writes into the repository's own dist/ directory and never commits
+# anything. Also confirms malformed/unsafe version input is rejected
+# before any artifact is written, and cannot be used to escape the
+# intended output directory.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+build_script="$repo_root/scripts/build_release.sh"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+if [[ ! -x "$build_script" ]]; then
+  fail "scripts/build_release.sh is missing or not executable"
+fi
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+output_dir="$work_dir/out"
+project_name="iphone-cam-lite"
+test_version="0.0.0-test"
+version_dir="${project_name}-${test_version}"
+
+echo "== Building a synthetic-version release into an isolated temp directory =="
+if ! "$build_script" "$test_version" "$output_dir" > "$work_dir/build_stdout.log" 2> "$work_dir/build_stderr.log"; then
+  cat "$work_dir/build_stderr.log" >&2
+  fail "build_release.sh exited nonzero for a valid version"
+fi
+echo "PASS: build_release.sh exited zero for a valid synthetic version"
+
+tar_path="$output_dir/${version_dir}.tar.gz"
+zip_path="$output_dir/${version_dir}.zip"
+sums_path="$output_dir/${version_dir}-SHA256SUMS.txt"
+
+echo
+echo "== Artifact existence and non-emptiness =="
+for artifact in "$tar_path" "$zip_path" "$sums_path"; do
+  if [[ ! -s "$artifact" ]]; then
+    fail "expected artifact missing or empty: $artifact"
+  fi
+done
+echo "PASS: tar.gz, zip, and SHA256SUMS were all created and are nonempty"
+
+echo
+echo "== Checksum verification =="
+if ! grep -qF "$(basename "$tar_path")" "$sums_path"; then
+  fail "SHA256SUMS does not list $(basename "$tar_path")"
+fi
+if ! grep -qF "$(basename "$zip_path")" "$sums_path"; then
+  fail "SHA256SUMS does not list $(basename "$zip_path")"
+fi
+if ! ( cd "$output_dir" && shasum -a 256 -c "$(basename "$sums_path")" > "$work_dir/shasum_check.log" 2>&1 ); then
+  cat "$work_dir/shasum_check.log" >&2
+  fail "shasum -c reported a checksum mismatch"
+fi
+echo "PASS: SHA256SUMS lists both archives and verifies against their actual contents"
+
+echo
+echo "== Archive naming and top-level directory =="
+if [[ "$(basename "$tar_path")" != "${version_dir}.tar.gz" ]]; then
+  fail "tar.gz name does not follow the <project>-<version>.tar.gz convention"
+fi
+if [[ "$(basename "$zip_path")" != "${version_dir}.zip" ]]; then
+  fail "zip name does not follow the <project>-<version>.zip convention"
+fi
+
+tar_entries="$(tar -tzf "$tar_path")"
+stray_tar="$(echo "$tar_entries" | grep -v "^${version_dir}/" || true)"
+if [[ -n "$stray_tar" ]]; then
+  fail "tar.gz contains entries outside the '${version_dir}/' top-level directory: $stray_tar"
+fi
+echo "PASS: tar.gz has exactly one versioned top-level directory"
+
+zip_entries="$(unzip -Z1 "$zip_path")"
+stray_zip="$(echo "$zip_entries" | grep -v "^${version_dir}/" || true)"
+if [[ -n "$stray_zip" ]]; then
+  fail "zip contains entries outside the '${version_dir}/' top-level directory: $stray_zip"
+fi
+echo "PASS: zip has exactly one versioned top-level directory"
+
+echo
+echo "== No absolute paths or parent-directory traversal =="
+if echo "$tar_entries" | grep -qE '^/|\.\./'; then
+  fail "tar.gz contains an absolute path or parent-directory traversal entry"
+fi
+if echo "$zip_entries" | grep -qE '^/|\.\./'; then
+  fail "zip contains an absolute path or parent-directory traversal entry"
+fi
+echo "PASS: neither archive contains an absolute path or '../' entry"
+
+echo
+echo "== Extraction and required/excluded file checks =="
+extract_tar_dir="$work_dir/extract_tar"
+extract_zip_dir="$work_dir/extract_zip"
+mkdir -p "$extract_tar_dir" "$extract_zip_dir"
+tar -xzf "$tar_path" -C "$extract_tar_dir"
+unzip -q "$zip_path" -d "$extract_zip_dir"
+
+required_files=(
+  "Makefile"
+  "README.md"
+  "CHANGELOG.md"
+  "SECURITY.md"
+  "LICENSE"
+  "scripts/check_prereqs.sh"
+  "scripts/start_zoom.sh"
+  "scripts/start_teams.sh"
+  "scripts/keepawake.sh"
+  "scripts/reset_camera_services.sh"
+  "scripts/select_zoom_camera.scpt"
+  "scripts/select_teams_camera.scpt"
+)
+for pkg_root in "$extract_tar_dir/$version_dir" "$extract_zip_dir/$version_dir"; do
+  for rel in "${required_files[@]}"; do
+    if [[ ! -f "$pkg_root/$rel" ]]; then
+      fail "required runtime file missing from package: $rel (in $pkg_root)"
+    fi
+  done
+done
+echo "PASS: every required runtime file is present in both extracted archives"
+
+excluded_paths=(
+  ".git"
+  ".github"
+  "tests"
+  "dist"
+  "_to_delete"
+  ".env"
+  ".DS_Store"
+  "CONTRIBUTING.md"
+  "ROADMAP.md"
+)
+for pkg_root in "$extract_tar_dir/$version_dir" "$extract_zip_dir/$version_dir"; do
+  for rel in "${excluded_paths[@]}"; do
+    if [[ -e "$pkg_root/$rel" ]]; then
+      fail "excluded development path was found in the package: $rel (in $pkg_root)"
+    fi
+  done
+  # No scripts/test_*.sh or build_release.sh should ship in the archive --
+  # those are development/release-engineering tooling, not runtime files.
+  if compgen -G "$pkg_root/scripts/test_*.sh" > /dev/null 2>&1; then
+    fail "found scripts/test_*.sh in the package at $pkg_root -- test scripts must not ship in a release archive"
+  fi
+  if [[ -e "$pkg_root/scripts/build_release.sh" ]]; then
+    fail "found scripts/build_release.sh in the package at $pkg_root -- the packaging script itself must not ship in a release archive"
+  fi
+done
+echo "PASS: excluded development files/directories are absent from both extracted archives"
+
+echo
+echo "== Executable modes preserved in the tar archive =="
+runnable_scripts=(start_zoom.sh start_teams.sh check_prereqs.sh keepawake.sh reset_camera_services.sh)
+for name in "${runnable_scripts[@]}"; do
+  f="$extract_tar_dir/$version_dir/scripts/$name"
+  if [[ ! -x "$f" ]]; then
+    fail "scripts/$name lost its executable mode in the tar.gz archive"
+  fi
+done
+for scpt in select_zoom_camera.scpt select_teams_camera.scpt; do
+  f="$extract_tar_dir/$version_dir/scripts/$scpt"
+  if [[ -x "$f" ]]; then
+    fail "scripts/$scpt should not be executable in the packaged archive"
+  fi
+done
+echo "PASS: runnable shell scripts kept their executable mode, and AppleScript sources stayed non-executable, in the tar.gz archive"
+
+echo
+echo "== Packaged shell scripts still pass bash -n =="
+while IFS= read -r -d '' f; do
+  if ! bash -n "$f"; then
+    fail "bash -n failed for packaged script: $f"
+  fi
+done < <(find "$extract_tar_dir/$version_dir/scripts" -name '*.sh' -print0)
+echo "PASS: every packaged .sh file passes 'bash -n'"
+
+echo
+echo "== make -n against the extracted package =="
+if ! ( cd "$extract_tar_dir/$version_dir" && make -n setup zoom teams keepawake reset-camera > /dev/null 2>&1 ); then
+  fail "'make -n' failed against the extracted package's Makefile"
+fi
+echo "PASS: 'make -n' dry-runs the extracted package's operational targets cleanly"
+
+echo
+echo "== Malformed and unsafe version rejection =="
+bad_versions=("" "1.2" "1.2.3.4" "abc" "1.2.3/../evil" "1.2.3; rm -rf /" " 1.2.3" "v" "1.2.3 ")
+bad_index=0
+for bad in "${bad_versions[@]}"; do
+  bad_index=$((bad_index + 1))
+  reject_out_dir="$work_dir/reject_$bad_index"
+  set +e
+  "$build_script" "$bad" "$reject_out_dir" > "$work_dir/reject_stdout.log" 2> "$work_dir/reject_stderr.log"
+  reject_status=$?
+  set -e
+  if [[ $reject_status -eq 0 ]]; then
+    fail "build_release.sh accepted an invalid version: \"$bad\""
+  fi
+  if [[ -d "$reject_out_dir" ]] && find "$reject_out_dir" -mindepth 1 -print -quit | grep -q .; then
+    fail "build_release.sh left artifacts behind for a rejected version: \"$bad\""
+  fi
+done
+echo "PASS: every malformed/unsafe version string was rejected with no artifacts written"
+
+echo
+echo "== A version cannot be used to escape the intended output directory =="
+traversal_dir="$work_dir/traversal_out"
+canary_path="/tmp/build_release_traversal_canary_$$"
+rm -f "$canary_path"
+set +e
+"$build_script" "../../../../../../tmp/build_release_traversal_canary_$$" "$traversal_dir" > "$work_dir/traversal_stdout.log" 2> "$work_dir/traversal_stderr.log"
+traversal_status=$?
+set -e
+if [[ $traversal_status -eq 0 ]]; then
+  fail "build_release.sh accepted a path-traversal version string"
+fi
+if [[ -e "$canary_path" ]]; then
+  rm -rf "$canary_path"
+  fail "a path-traversal version string escaped the intended output directory"
+fi
+echo "PASS: a path-traversal version string is rejected and cannot escape the output directory"
+
+echo
+echo "All release-packaging regression checks passed."

--- a/scripts/test_reset_camera_services.sh
+++ b/scripts/test_reset_camera_services.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Safety regression test for scripts/reset_camera_services.sh.
+#
+# That script restarts camera-related system agents and kills a specific
+# helper process by name -- both are real system-changing operations, so
+# this test never lets the real launchctl/pkill run. It mocks both,
+# recording every invocation, and asserts: (a) the script only targets the
+# specific, documented services/process pattern (never a broad wildcard or
+# unrelated target), (b) a failing launchctl/pkill does not abort the
+# script (each is guarded with "|| true"), and (c) the script contains no
+# other destructive command (rm -rf, sudo, shutdown, reboot, diskutil...).
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script_path="$repo_root/scripts/reset_camera_services.sh"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+mock_dir="$(mktemp -d)"
+trap 'rm -rf "$mock_dir"' EXIT
+
+write_mock() {
+  local name="$1" body="$2"
+  cat > "$mock_dir/$name" <<EOF
+#!/usr/bin/env bash
+$body
+EOF
+  chmod +x "$mock_dir/$name"
+}
+
+if [[ ! -f "$script_path" ]]; then
+  fail "scripts/reset_camera_services.sh not found"
+fi
+
+echo "== Static checks: only the documented, specific targets are used =="
+
+if ! grep -q '^set -euo pipefail$' "$script_path"; then
+  fail "reset_camera_services.sh does not enable 'set -euo pipefail'"
+fi
+
+# Every external command that changes system state must be guarded with
+# "|| true" so a single missing/failing agent never aborts the rest of the
+# reset, and never propagates a nonzero exit for something this script
+# cannot control (like a service that's already stopped).
+for pattern in 'launchctl kickstart' 'pkill -f'; do
+  line="$(grep -F "$pattern" "$script_path" || true)"
+  if [[ -z "$line" ]]; then
+    fail "expected a '$pattern' invocation in reset_camera_services.sh"
+  fi
+  if ! echo "$line" | grep -q '|| true'; then
+    fail "expected '$pattern' to be guarded with '|| true' so a failure doesn't abort the script: $line"
+  fi
+done
+
+# No unrelated destructive command should ever be introduced here.
+for dangerous in 'rm -rf' 'sudo ' 'shutdown' 'reboot' 'diskutil' 'dd if=' 'mkfs'; do
+  if grep -qF "$dangerous" "$script_path"; then
+    fail "found an unexpected destructive command ('$dangerous') in reset_camera_services.sh"
+  fi
+done
+echo "PASS: [static] set -euo pipefail is enabled, launchctl/pkill are guarded with '|| true', and no unrelated destructive command is present"
+
+# pkill must target a specific, named pattern -- never an empty or
+# wildcard-only pattern that could match unrelated processes.
+pkill_pattern="$(grep -oE 'pkill -f "[^"]*"' "$script_path" | head -1 | sed -E 's/pkill -f "(.*)"/\1/')"
+if [[ -z "$pkill_pattern" ]]; then
+  fail "pkill -f pattern is empty or could not be parsed from reset_camera_services.sh -- an empty pattern could match unrelated processes"
+fi
+echo "PASS: [static] pkill targets a specific non-empty pattern (\"$pkill_pattern\"), not an unbounded match"
+
+echo
+echo "== Mocked execution: launchctl/pkill are invoked, never run for real =="
+
+invocations_file="$mock_dir/invocations.log"
+: > "$invocations_file"
+
+write_mock launchctl "
+echo \"launchctl \$*\" >> '$invocations_file'
+exit 0
+"
+write_mock pkill "
+echo \"pkill \$*\" >> '$invocations_file'
+exit 0
+"
+
+out_file="$mock_dir/stdout.log"
+err_file="$mock_dir/stderr.log"
+set +e
+PATH="$mock_dir:$PATH" bash "$script_path" > "$out_file" 2> "$err_file"
+status=$?
+set -e
+
+if [[ $status -ne 0 ]]; then
+  fail "reset_camera_services.sh exited nonzero ($status) against successful mocks: $(cat "$err_file")"
+fi
+
+if ! grep -q 'launchctl kickstart -k system/com.apple.cmio.AVCAssistant' "$invocations_file"; then
+  fail "expected a launchctl kickstart invocation for com.apple.cmio.AVCAssistant"
+fi
+if ! grep -q 'launchctl kickstart -k gui/' "$invocations_file"; then
+  fail "expected a launchctl kickstart invocation for the per-user AppleCameraAssistant agent"
+fi
+if ! grep -qF "pkill -f $pkill_pattern" "$invocations_file"; then
+  fail "expected pkill to be invoked with the documented pattern \"$pkill_pattern\""
+fi
+echo "PASS: [mocked] launchctl and pkill were invoked with the documented targets, and the script exited zero"
+
+echo
+echo "== Mocked failure: a failing launchctl/pkill must not abort the script =="
+
+write_mock launchctl "
+echo \"launchctl \$*\" >> '$invocations_file'
+exit 1
+"
+write_mock pkill "
+echo \"pkill \$*\" >> '$invocations_file'
+exit 1
+"
+
+set +e
+PATH="$mock_dir:$PATH" bash "$script_path" > "$out_file" 2> "$err_file"
+status=$?
+set -e
+
+if [[ $status -ne 0 ]]; then
+  fail "reset_camera_services.sh exited nonzero ($status) when launchctl/pkill failed -- '|| true' should have absorbed this: $(cat "$err_file")"
+fi
+if ! grep -q "Done." "$out_file"; then
+  fail "expected the completion message even after launchctl/pkill reported failure"
+fi
+echo "PASS: [mocked] a failing launchctl/pkill does not abort the script; it still completes and exits zero"
+
+echo
+echo "All reset_camera_services.sh safety regression checks passed."

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Single entry point for the whole test suite: discovers and runs every
+# scripts/test_*.sh regression test deterministically (sorted by
+# filename), prints a PASS/FAIL line for each, and exits nonzero if any
+# failed. This is what `make test` calls.
+#
+# Discovery (rather than a hardcoded list) means a newly added
+# scripts/test_*.sh file is picked up automatically the next time this
+# runs -- no test can be silently left out of the suite.
+#
+# This runner performs no system-changing operations itself; each
+# individual test file is responsible for mocking any external command it
+# needs (launchctl, pkill, open, pgrep, osascript, ...), so running the
+# full suite here never launches Zoom, Teams, System Events automation,
+# or touches real camera/media services.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+test_files=()
+while IFS= read -r -d '' f; do
+  test_files+=("$f")
+done < <(find "$repo_root/scripts" -maxdepth 1 -name 'test_*.sh' -print0 | sort -z)
+
+if [[ ${#test_files[@]} -eq 0 ]]; then
+  echo "FAIL: no scripts/test_*.sh files were found -- test discovery is broken" >&2
+  exit 1
+fi
+
+pass_count=0
+fail_count=0
+failed_names=()
+
+for test_file in "${test_files[@]}"; do
+  test_name="$(basename "$test_file")"
+  echo "== $test_name =="
+  if bash "$test_file"; then
+    echo "RESULT: PASS -- $test_name"
+    pass_count=$((pass_count + 1))
+  else
+    echo "RESULT: FAIL -- $test_name" >&2
+    fail_count=$((fail_count + 1))
+    failed_names+=("$test_name")
+  fi
+  echo
+done
+
+echo "== Summary =="
+echo "$pass_count passed, $fail_count failed, ${#test_files[@]} total"
+
+if [[ $fail_count -gt 0 ]]; then
+  echo "Failed tests:" >&2
+  for name in "${failed_names[@]}"; do
+    echo "  - $name" >&2
+  done
+  exit 1
+fi
+
+echo "All tests passed."


### PR DESCRIPTION
Tests added:

- scripts/test_build_release.sh — 229 lines, builds a real synthetic-version release into an isolated temp dir and checks existence, checksums, naming, top-level-dir structure, no path traversal, required/excluded file contents, executable-mode preservation, bash -n on packaged scripts, make -n dry-run, and rejection of 8 malformed/unsafe version strings plus a path-traversal attempt.
- scripts/test_reset_camera_services.sh — 137 lines, statically checks set -euo pipefail and || true guards, then mocks launchctl/pkill to prove both the success and failure paths never abort or run real system commands.
- tests/run.sh — glob-based discovery of all scripts/test_*.sh (no hardcoded list), used by make test.
- Full suite result: 8/9 pass; test_check_prereqs.sh fails on the pre-existing, unrelated IFCONFIG_LOG: unbound variable bug documented earlier in this engagement — explicitly out of scope per the "no unrelated cleanup" instruction.